### PR TITLE
Build action test

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -13,19 +14,16 @@ jobs:
         include:
           - os: windows-latest
             build_cmd: npm run build-win64
-            artifact: dist/soracom-button-Setup-${{ steps.version.outputs.version }}_win64.exe
+            artifact_suffix: _win64.exe
             src: build/win-unpacked/soracom-button Setup.exe
-            rename: soracom-button-Setup-${{ steps.version.outputs.version }}_win64.exe
           - os: windows-latest
             build_cmd: npm run build-win32
-            artifact: dist/soracom-button-Setup-${{ steps.version.outputs.version }}_win32.exe
+            artifact_suffix: _win32.exe
             src: build/win-ia32-unpacked/soracom-button Setup.exe
-            rename: soracom-button-Setup-${{ steps.version.outputs.version }}_win32.exe
           - os: macos-latest
             build_cmd: npm run build-mac
-            artifact: dist/soracom-button-Setup-${{ steps.version.outputs.version }}.dmg
+            artifact_suffix: .dmg
             src: build/mac/*.dmg
-            rename: soracom-button-Setup-${{ steps.version.outputs.version }}.dmg
 
     steps:
       - uses: actions/checkout@v4
@@ -46,22 +44,30 @@ jobs:
       - name: Build
         run: ${{ matrix.build_cmd }}
 
-      - name: Find built file and rename
-        shell: bash
+      - name: Build
+        run: ${{ matrix.build_cmd }}
+
+      - name: Set artifact name
+        id: set_artifact_name
+        run: echo "artifact_name=soracom-button-Setup-${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}" >> $GITHUB_ENV
+
+      - name: Rename files
         run: |
           mkdir -p dist
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             src_file=$(ls build/mac/*.dmg | head -n 1)
           else
             src_file="${{ matrix.src }}"
-          fi
+          cp "$src_file" "dist/${{ env.artifact_name }}"
           cp "$src_file" "dist/${{ matrix.rename }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.rename }}
-          path: dist/${{ matrix.rename }}
+          name: ${{ env.artifact_name }}
+          path: |
+            dist/${{ env.artifact_name }}
+            dist/${{ matrix.rename }}
 
   release:
     needs: build

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Build release binaries
         run: ${{ matrix.build_cmd }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}            
 
       - name: Set artifact name
         id: set_artifact_name

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,15 +13,15 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            build_cmd: npm run build-win64
+            build_cmd: npm run build-win64 --publish-never
             artifact_suffix: _win64.exe
             src: build/win-unpacked/soracom-button Setup.exe
           - os: windows-latest
-            build_cmd: npm run build-win32
+            build_cmd: npm run build-win32 --publish-never
             artifact_suffix: _win32.exe
             src: build/win-ia32-unpacked/soracom-button Setup.exe
           - os: macos-latest
-            build_cmd: npm run build-mac
+            build_cmd: npm run build-mac --publish-never
             artifact_suffix: .dmg
             src: build/mac/*.dmg
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -28,15 +28,11 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            build_cmd: npm run build-win64 --publish-never
+            build_cmd: npm run build-win64
           - os: windows-latest
-            build_cmd: npm run build-win32 --publish-never
-            artifact_suffix: _win32.exe
-            src: build/win-ia32-unpacked/soracom-button Setup.exe
+            build_cmd: npm run build-win32
           - os: macos-latest
-            build_cmd: npm run build-mac --publish-never
-            artifact_suffix: .dmg
-            src: build/mac/*.dmg
+            build_cmd: npm run build-mac
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -7,8 +7,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: true
+          prerelease: false
+
+  build-and-release:
     runs-on: ${{ matrix.os }}
+    needs: create-release
     strategy:
       matrix:
         include:
@@ -34,19 +49,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          draft: true
-          prerelease: false
-
       - name: Build
         run: npm run build
 
-      - name: Build release binaries
+      - name: Build and release binaries
         run: ${{ matrix.build_cmd }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}            
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,8 +14,6 @@ jobs:
         include:
           - os: windows-latest
             build_cmd: npm run build-win64 --publish-never
-            artifact_suffix: _win64.exe
-            src: build/win-unpacked/soracom-button Setup.exe
           - os: windows-latest
             build_cmd: npm run build-win32 --publish-never
             artifact_suffix: _win32.exe
@@ -36,10 +34,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get version
-        id: version
-        run: |
-          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: true
+          prerelease: false
 
       - name: Build
         run: npm run build
@@ -48,49 +50,3 @@ jobs:
         run: ${{ matrix.build_cmd }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}            
-
-      - name: Set artifact name
-        id: set_artifact_name
-        run: echo "artifact_name=soracom-button-Setup-${{ steps.version.outputs.version }}${{ matrix.artifact_suffix }}" >> $GITHUB_ENV
-
-      - name: Rename files
-        run: |
-          mkdir -p dist
-          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            src_file=$(ls build/mac/*.dmg | head -n 1)
-          else
-            src_file="${{ matrix.src }}"
-          fi
-          cp "$src_file" "dist/${{ env.artifact_name }}"
-          cp "$src_file" "dist/${{ matrix.rename }}"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.artifact_name }}
-          path: |
-            dist/${{ env.artifact_name }}
-            dist/${{ matrix.rename }}
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-          files: |
-            dist/soracom-button-Setup-*.exe
-            dist/soracom-button-Setup-*.dmg

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -42,9 +42,9 @@ jobs:
           echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Build
-        run: ${{ matrix.build_cmd }}
+        run: npm run build
 
-      - name: Build
+      - name: Build release binaries
         run: ${{ matrix.build_cmd }}
 
       - name: Set artifact name

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -60,6 +60,7 @@ jobs:
             src_file=$(ls build/mac/*.dmg | head -n 1)
           else
             src_file="${{ matrix.src }}"
+          fi
           cp "$src_file" "dist/${{ env.artifact_name }}"
           cp "$src_file" "dist/${{ matrix.rename }}"
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     },
     "nsis": {
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "artifactName": "${productName}-win-${arch}-${version}-setup.${ext}"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Please review in japanese.

This pull request refactors the GitHub Actions workflow for building and releasing the project, simplifying the process and consolidating steps. Additionally, it updates the `package.json` configuration to include a more descriptive artifact naming convention for Windows installers.

### Workflow refactoring:

* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bR7-L28): Introduced a `create-release` job to handle release creation separately, using `softprops/action-gh-release@v2`. This job is now a prerequisite for the `build-and-release` job, streamlining the release process.
* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL41-R54): Simplified the build process by removing redundant steps such as version extraction, artifact renaming, and artifact upload, and consolidated them into a single `Build and release binaries` step.

### Artifact naming improvement:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L60-R61): Updated the `artifactName` property in the `nsis` configuration to use a descriptive and consistent naming convention for Windows installer artifacts, including product name, architecture, version, and file extension.