### PR TITLE
Refactor release action

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,29 +1,18 @@
 name: Build and Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+    paths:
+      - 'package.json'
+      - 'src/**'
   workflow_dispatch:
 
 jobs:
-  create-release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          draft: true
-          prerelease: false
-
   build-and-release:
     runs-on: ${{ matrix.os }}
-    needs: create-release
     strategy:
       matrix:
         include:
@@ -44,9 +33,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Build
-        run: npm run build
 
       - name: Build and release binaries
         run: ${{ matrix.build_cmd }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -30,8 +30,6 @@ jobs:
           git push origin ${{ env.VERSION  }} --force
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: create tag
-        run: |
       
   build-and-release:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,18 +1,41 @@
 name: Build and Release
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  push:
     branches:
       - main
     paths:
-      - 'package.json'
-      - 'src/**'
+      - package.json
+      - src/**
   workflow_dispatch:
 
 jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # タグ操作には全履歴が必要
+      - name: Set up Git user
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+      - name: get version
+        id: get_version
+        run: |
+          echo "VERSION=v$(jq -r .version package.json)" >> $GITHUB_ENV
+      - name: Create or move tag
+        run: |
+          git tag -fa ${{ env.VERSION }} -m "Move tag to latest commit"
+          git push origin ${{ env.VERSION  }} --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: create tag
+        run: |
+      
   build-and-release:
     runs-on: ${{ matrix.os }}
+    needs: tag
     strategy:
       matrix:
         include:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SORACOM LTE-M Button for Enterprise Simulator
 
-This is a [SORACOM LTE-M Button for Enterprise](https://users.soracom.io/ja-jp/guides/iot-devices/lte-m-button-enterprise/) simulator applicaton works on Windows and Mac.
+This is a [SORACOM LTE-M Button for Enterprise](https://users.soracom.io/ja-jp/guides/iot-devices/lte-m-button-enterprise/) simulator application works on Windows and Mac.
 
 ## How to install 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # SORACOM LTE-M Button for Enterprise Simulator
 
-This is a [SORACOM LTE-M Button for Enterprise](https://users.soracom.io/ja-jp/guides/iot-devices/lte-m-button-enterprise/) simulator application works on Windows and Mac.
-
+This is a [SORACOM LTE-M Button for Enterprise](https://users.soracom.io/ja-jp/guides/iot-devices/lte-m-button-enterprise/) simulator application that works on Windows and Mac.
 ## How to install 
 
 Download and run the binary that matches your environment from the release page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soracom-button",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soracom-button",
-      "version": "0.6.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soracom-button",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soracom-button",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -47,15 +47,13 @@
       "src",
       "dist"
     ],
-    "publish": [
-      {
-        "provider": "github",
-        "owner": "kenichiro-kimura",
-        "repo": "kenichiro-kimura/soracom-button",
-        "releaseType": "draft",
-        "publishAutoUpdate": false
-      }
-    ],
+    "publish": {
+      "provider": "github",
+      "owner": "kenichiro-kimura",
+      "repo": "kenichiro-kimura/soracom-button",
+      "releaseType": "draft",
+      "publishAutoUpdate": false
+    },
     "mac": {
       "target": "dmg",
       "icon": "img/icon.png"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soracom-button",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "",
   "main": "dist/main.js",
   "dependencies": {
@@ -51,7 +51,7 @@
       {
         "publishAutoUpdate": false
       }
-    ],    
+    ],
     "mac": {
       "target": "dmg",
       "icon": "img/icon.png"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "publish": {
       "provider": "github",
       "owner": "kenichiro-kimura",
-      "repo": "kenichiro-kimura/soracom-button",
+      "repo": "soracom-button",
       "releaseType": "draft",
       "publishAutoUpdate": false
     },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
     ],
     "publish": [
       {
+        "provider": "github",
+        "owner": "kenichiro-kimura",
+        "repo": "kenichiro-kimura/soracom-button",
+        "releaseType": "draft",
         "publishAutoUpdate": false
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soracom-button",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "",
   "main": "dist/main.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "build": "tsc && npm run copy",
     "copy": "copyfiles -u 1 src/index.html src/js/**/* src/css/**/* src/img/**/* dist/",
     "start": "npm run build && electron .",
-    "build-mac": "electron-builder --mac --x64",
-    "build-win64": "electron-builder --win --x64",
-    "build-win32": "electron-builder --win --ia32",
+    "build-mac": "npm run build && electron-builder --mac --x64",
+    "build-win64": "npm run build && electron-builder --win --x64",
+    "build-win32": "npm run build && electron-builder --win --ia32",
     "lint": "eslint --ext .ts ./src",
     "prepare": "husky init"
   },
@@ -47,6 +47,11 @@
       "src",
       "dist"
     ],
+    "publish": [
+      {
+        "publishAutoUpdate": false
+      }
+    ],    
     "mac": {
       "target": "dmg",
       "icon": "img/icon.png"

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "build": "tsc && npm run copy",
     "copy": "copyfiles -u 1 src/index.html src/js/**/* src/css/**/* src/img/**/* dist/",
     "start": "npm run build && electron .",
-    "build-mac": "npm run build && electron-builder --mac --x64",
-    "build-win64": "npm run build && electron-builder --win --x64",
-    "build-win32": "npm run build && electron-builder --win --ia32",
+    "build-mac": "npm run build && electron-builder --mac --x64 --publish always",
+    "build-win64": "npm run build && electron-builder --win --x64 --publish always",
+    "build-win32": "npm run build && electron-builder --win --ia32 --publish always",
     "lint": "eslint --ext .ts ./src",
     "prepare": "husky init"
   },


### PR DESCRIPTION
Please review in Japanese.
close  #40 

This pull request introduces significant updates to the build and release workflow, as well as minor fixes and enhancements to the project configuration and documentation. The key changes include shifting the release process to use Git tags, automating binary publishing, and correcting a typo in the `README.md`.

### Workflow and Build Process Updates:
* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL5-R36): Replaced the `create-release` job with a `tag` job that creates or moves Git tags based on the version in `package.json`. Updated the workflow trigger to monitor changes in the `main` branch and specific paths instead of tags. Removed the explicit release creation process.
* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL48-L50): Removed the standalone `Build` step, consolidating it into the `Build and release binaries` step.

### Project Configuration Enhancements:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R36): Updated build scripts to include the `--publish always` flag, enabling automatic publishing of binaries. Added a `publish` configuration for GitHub releases, specifying the repository owner, repository name, and release type as a draft. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R36) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R50-R56)

### Documentation Fix:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Fixed a typo in the description by correcting "applicaton" to "application."