### PR TITLE
fix: remove unnecessary tag creation steps from build workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -2,38 +2,13 @@ name: Build and Release
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - package.json
-      - src/**
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
 
 jobs:
-  tag:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # タグ操作には全履歴が必要
-      - name: Set up Git user
-        run: |
-          git config --global user.name 'github-actions'
-          git config --global user.email 'github-actions@github.com'
-      - name: get version
-        id: get_version
-        run: |
-          echo "VERSION=v$(jq -r .version package.json)" >> $GITHUB_ENV
-      - name: Create or move tag
-        run: |
-          git tag -fa ${{ env.VERSION }} -m "Move tag to latest commit"
-          git push origin ${{ env.VERSION  }} --force
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
   build-and-release:
     runs-on: ${{ matrix.os }}
-    needs: tag
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Please review in Japanes.
close #42 

This pull request modifies the GitHub Actions workflow to streamline the build and release process by transitioning from branch-based triggers to tag-based triggers and removing the `tag` job. 

### Workflow Trigger Changes:
* Updated the `on.push` configuration to trigger the workflow on tags matching the pattern `v*.*.*` instead of specific branches and paths. (`.github/workflows/build-and-release.yml`, [.github/workflows/build-and-release.ymlL5-L36](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL5-L36))

### Job Simplification:
* Removed the `tag` job, which previously handled creating or moving Git tags, as it is no longer needed with the new tag-based workflow trigger. (`.github/workflows/build-and-release.yml`, [.github/workflows/build-and-release.ymlL5-L36](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL5-L36))